### PR TITLE
[telepathy-ring] Fix incorrect parsing of SMS sent time

### DIFF
--- a/modem/sms-service.c
+++ b/modem/sms-service.c
@@ -624,12 +624,11 @@ modem_sms_service_time_connected (ModemSMSService const *self)
 gint64
 modem_sms_parse_time (gchar const *s)
 {
-  struct tm tm = { };
-  char *rest;
-
-  rest = strptime (s, "%Y-%m-%dT%H:%M:%S%z", &tm);
-
-  return (gint64) mktime (&tm);
+  GTimeVal val;
+  if (g_time_val_from_iso8601(s, &val))
+      return val.tv_sec;
+  else
+      return 0;
 }
 
 

--- a/src/ring-text-manager.c
+++ b/src/ring-text-manager.c
@@ -950,13 +950,13 @@ receive_text (RingTextManager *self,
 {
   char const *sent;
   char *token;
-  gint64 message_sent;
+  gint64 message_sent = 0;
   gint64 message_received = (gint64) time(NULL);
 
   sent = tp_asv_get_string (info, "SentTime");
   if (sent)
     message_sent = modem_sms_parse_time (sent);
-  else
+  if (!message_sent)
     message_sent = message_received;
 
   token = generate_token ();


### PR DESCRIPTION
The SentTime from ofono is in a local timezone, and strptime+mktime
didn't correctly account for that, resulting in SMS timestamps being off
by an hour or more.

Should this return the current time instead of 0 in case of parsing failure?
