### PR TITLE
Remove assertion about self handle after connection disposal

### DIFF
--- a/src/ring-connection.c
+++ b/src/ring-connection.c
@@ -249,7 +249,6 @@ ring_connection_dispose(GObject *object)
     g_object_unref(self->priv->sim);
 
   G_OBJECT_CLASS(ring_connection_parent_class)->dispose(object);
-  g_assert(self->parent.self_handle == 0);  /* unref'd by base class */
 }
 
 void


### PR DESCRIPTION
Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com

When a connection is disposed, the self handle is not always reset. But there is no good reason to have the sub-class assert about a parent-class state. Also, the connection object is really disposed and not re-used, so this clean-up detail is really not important.
