### PR TITLE
Enable local playing of call error tones (but not alert tone, DTMF)

### DIFF
--- a/src/ring-call-channel.c
+++ b/src/ring-call-channel.c
@@ -694,8 +694,10 @@ ring_call_channel_update_state(RingMediaChannel *_self,
       ring_media_channel_stop_playing(RING_MEDIA_CHANNEL(self), TRUE);
       break;
     case MODEM_CALL_STATE_ALERTING:
+#if 0 /* No local alert tone (use in-band audio) */
       ring_media_channel_play_tone(RING_MEDIA_CHANNEL(self),
         TONES_EVENT_RINGING, 0, 0);
+#endif
       break;
     case MODEM_CALL_STATE_DISCONNECTED:
       ring_call_channel_play_error_tone(self, state, causetype, cause);

--- a/src/ring-media-channel.c
+++ b/src/ring-media-channel.c
@@ -679,11 +679,13 @@ ring_media_channel_dtmf_start_tone_replied(ModemCall *call_instance,
 
     priv->dtmf.digit = dtmf;
 
+#if 0 /* No local DTMF playback (handled by UI) */
     if (event) {
       ring_media_channel_play_tone(self,
         event - ring_media_channel_dtmf_events,
         -6, 20000);
     }
+#endif
 
     tp_svc_channel_interface_dtmf_return_from_start_tone(context);
   }
@@ -1451,7 +1453,9 @@ on_modem_call_dtmf_tone(ModemCall *call_instance,
     return;
 
   if (0 <= tone && tone <= 14) {
+#if 0 /* No local DTMF playback (handled by UI) */
     ring_media_channel_play_tone(RING_MEDIA_CHANNEL(self), tone, -6, 2000);
+#endif
   }
   else {
     ring_media_channel_stop_playing(RING_MEDIA_CHANNEL(self), FALSE);
@@ -1474,9 +1478,7 @@ ring_media_channel_play_tone(RingMediaChannel *self,
   if (priv->closing)
     return;
 
-  if (1)
-    /* XXX - no tones so far */
-    return;
+  DEBUG("play tone %d for %u ms at %d dBm0", tone, duration, volume);
 
   if ((tone >= 0 && !modem_tones_is_playing(priv->tones, 0))
     || priv->playing) {


### PR DESCRIPTION
telepathy-ring uses tonegend (https://github.com/nemomobile/tone-generator) to play "busy" and "radio channel lost" tones when a call disconnects. This patch enables some old "dead code", but also disables cases where we do not want local tone generation: MO call alerting (using in-band audio from the network) and in-call DTMF (local tones generated by voicecall UI).
