### PR TITLE
Disconnect of IncomingMessage and ImmediateMessage signals

### DIFF
--- a/modem/sms-service.c
+++ b/modem/sms-service.c
@@ -391,9 +391,9 @@ modem_sms_service_disconnect (ModemOface *_self)
     {
       priv->signals = FALSE;
 
-      dbus_g_proxy_disconnect_signal (proxy, "IncomingMessage",
-          G_CALLBACK (on_immediate_message), self);
       dbus_g_proxy_disconnect_signal (proxy, "ImmediateMessage",
+          G_CALLBACK (on_immediate_message), self);
+      dbus_g_proxy_disconnect_signal (proxy, "IncomingMessage",
           G_CALLBACK (on_incoming_message), self);
       dbus_g_proxy_disconnect_signal (proxy, "MessageAdded",
           G_CALLBACK (on_manager_message_added), self);


### PR DESCRIPTION
Noticed mismatch between dbus_g_proxy_connect_signal and dbus_g_proxy_disconnect_signal calls.
