### PR TITLE
Listen to new oFono SMS History API

### DIFF
--- a/modem/Makefile.am
+++ b/modem/Makefile.am
@@ -44,9 +44,9 @@ modem_HEADERS += call.h tones.h
 
 libmodem_glib_la_SOURCES += call-service.c call.c tones.c
 
-modem_HEADERS += sms.h sms-message.h
+modem_HEADERS += sms.h sms-message.h sms-history.h
 
-libmodem_glib_la_SOURCES += sms-service.c sms-message.c
+libmodem_glib_la_SOURCES += sms-service.c sms-message.c sms-history.c
 
 modem_HEADERS += sim.h
 

--- a/modem/sms-history.c
+++ b/modem/sms-history.c
@@ -1,0 +1,141 @@
+/*
+ * modem/sms-history.c - oFono SMS History interface
+ *
+ * Copyright (C) 2013 Jolla Ltd
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#define MODEM_DEBUG_FLAG MODEM_LOG_SMS
+
+#include "debug.h"
+
+#include "modem/sms-history.h"
+#include "modem/sms.h"
+#include "modem/ofono.h"
+#include "modem/modem.h"
+#include "modem/service.h"
+
+#include <dbus/dbus-glib.h>
+#include "signals-marshal.h"
+
+/* ------------------------------------------------------------------------ */
+
+G_DEFINE_TYPE (ModemSmsHistory, modem_sms_history, MODEM_TYPE_OFACE);
+
+/* ------------------------------------------------------------------------ */
+
+static void
+modem_sms_history_init (ModemSmsHistory *self)
+{
+  DEBUG ("enter");
+}
+
+static void
+modem_sms_history_constructed (GObject *object)
+{
+  if (G_OBJECT_CLASS (modem_sms_history_parent_class)->constructed)
+    G_OBJECT_CLASS (modem_sms_history_parent_class)->constructed (object);
+}
+
+static void
+modem_sms_history_dispose (GObject *object)
+{
+  if (G_OBJECT_CLASS (modem_sms_history_parent_class)->dispose)
+    G_OBJECT_CLASS (modem_sms_history_parent_class)->dispose (object);
+}
+
+static void
+modem_sms_history_finalize (GObject *object)
+{
+  DEBUG ("enter");
+}
+
+static void on_sms_history_status_report (DBusGProxy *proxy,
+        char const *token,
+        GHashTable *dict,
+        gpointer user_data)
+{
+  ModemSmsHistory *self = MODEM_SMS_HISTORY(user_data);
+  ModemService *modemService = modem_service();
+  if (!modemService)
+    return;
+
+  Modem *modem = modem_service_find_by_path (modemService, dbus_g_proxy_get_path(proxy));
+  if (!modem)
+    return;
+
+  ModemSMSService *smsService = MODEM_SMS_SERVICE(modem_get_interface (modem, MODEM_OFACE_SMS));
+  if (!smsService)
+    return;
+
+  on_manager_message_status_report(proxy, token, dict, smsService);
+}
+
+/* ------------------------------------------------------------------------- */
+/* ModemOface interface */
+
+static void
+modem_sms_history_connect (ModemOface *_self)
+{
+  DEBUG ("(%p): enter", _self);
+
+  ModemSmsHistory *self = MODEM_SMS_HISTORY (_self);
+  DBusGProxy *proxy = modem_oface_dbus_proxy (_self);
+  dbus_g_proxy_add_signal (proxy, "StatusReport",
+      G_TYPE_STRING, MODEM_TYPE_DBUS_DICT, G_TYPE_INVALID);
+  dbus_g_proxy_connect_signal (proxy, "StatusReport",
+      G_CALLBACK (on_sms_history_status_report), self, NULL);
+}
+
+static void
+modem_sms_history_connected (ModemOface *_self)
+{
+  DEBUG ("(%p): enter", _self);
+}
+
+static void
+modem_sms_history_disconnect (ModemOface *_self)
+{
+  DEBUG ("(%p): enter", _self);
+  DBusGProxy *proxy = modem_oface_dbus_proxy (_self);
+  ModemSmsHistory *self = MODEM_SMS_HISTORY (_self);
+  dbus_g_proxy_disconnect_signal (proxy, "StatusReport",
+      G_CALLBACK (on_sms_history_status_report), self);
+}
+
+static void
+modem_sms_history_class_init (ModemSmsHistoryClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ModemOfaceClass *oface_class = MODEM_OFACE_CLASS (klass);
+
+  DEBUG ("enter");
+
+  object_class->constructed = modem_sms_history_constructed;
+  object_class->dispose = modem_sms_history_dispose;
+  object_class->finalize = modem_sms_history_finalize;
+
+  oface_class->ofono_interface = MODEM_OFACE_SMS_HISTORY;
+  oface_class->connect = modem_sms_history_connect;
+  oface_class->connected = modem_sms_history_connected;
+  oface_class->disconnect = modem_sms_history_disconnect;
+
+  modem_error_domain_prefix (0); /* Init errors */
+}
+
+

--- a/modem/sms-history.h
+++ b/modem/sms-history.h
@@ -1,0 +1,67 @@
+/*
+ * modem/sms-history.h - oFono SMS History interface
+ *
+ * Copyright (C) 2013 Jolla Ltd
+  *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _MODEM_SMS_HISTORY_H_
+#define _MODEM_SMS_HISTORY_H_
+
+#include <glib-object.h>
+#include <modem/oface.h>
+
+G_BEGIN_DECLS
+
+#define MODEM_OFACE_SMS_HISTORY "org.ofono.SmsHistory"
+
+typedef struct _ModemSmsHistory ModemSmsHistory;
+typedef struct _ModemSmsHistoryClass ModemSmsHistoryClass;
+
+struct _ModemSmsHistoryClass
+{
+  ModemOfaceClass parent_class;
+};
+
+struct _ModemSmsHistory
+{
+  ModemOface parent;
+};
+
+GType modem_sms_history_get_type (void);
+
+/* TYPE MACROS */
+#define MODEM_TYPE_SMS_HISTORY                  \
+  (modem_sms_history_get_type ())
+#define MODEM_SMS_HISTORY(obj)                  \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj),           \
+      MODEM_TYPE_SMS_HISTORY, ModemSmsHistory))
+#define MODEM_SMS_HISTORY_CLASS(klass)                  \
+  (G_TYPE_CHECK_CLASS_CAST ((klass),                    \
+      MODEM_TYPE_SMS_HISTORY, ModemSmsHistoryClass))
+#define MODEM_IS_SMS_HISTORY(obj)                               \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), MODEM_TYPE_SMS_HISTORY))
+#define MODEM_IS_SMS_HISTORY_CLASS(klass)                       \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), MODEM_TYPE_SMS_HISTORY))
+#define MODEM_SMS_HISTORY_GET_CLASS(obj)                \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj),                    \
+      MODEM_TYPE_SMS_HISTORY, ModemSmsHistoryClass))
+
+/* ---------------------------------------------------------------------- */
+
+G_END_DECLS
+
+#endif /* #ifndef _MODEM_SMS_HISTORY_H_*/

--- a/modem/sms-service.c
+++ b/modem/sms-service.c
@@ -28,6 +28,7 @@
 
 #include "modem/sms.h"
 #include "modem/sms-message.h"
+#include "modem/sms-history.h"
 #include "modem/request-private.h"
 #include "modem/errors.h"
 
@@ -117,8 +118,6 @@ static void on_immediate_message (DBusGProxy *, char const *, GHashTable *, gpoi
 static void on_manager_message_added (DBusGProxy *, char const *, GHashTable *,
     gpointer);
 static void on_manager_message_removed (DBusGProxy *, char const *, gpointer);
-static void on_manager_message_status_report (DBusGProxy *, char const *, GHashTable *,
-    gpointer);
 
 /* ------------------------------------------------------------------------ */
 /* GObject interface */
@@ -541,6 +540,9 @@ modem_sms_service_class_init (ModemSMSServiceClass *klass)
 #endif
 
   g_type_class_add_private (klass, sizeof (ModemSMSServicePrivate));
+
+  modem_oface_register_type(MODEM_TYPE_SMS_HISTORY);
+
 }
 
 /* ---------------------------------------------------------------------- */
@@ -676,7 +678,7 @@ on_manager_message_removed (DBusGProxy *proxy,
   }
 }
 
-static void
+void
 on_manager_message_status_report (DBusGProxy *proxy,
                      char const *token,
                      GHashTable *dict,

--- a/modem/sms.h
+++ b/modem/sms.h
@@ -122,6 +122,9 @@ void modem_sms_emit_outgoing(ModemSMSService *self, char *address, char *path);
 void modem_sms_emit_error(ModemSMSService *self, char *address, char *path,
 		GError error);
 
+void on_manager_message_status_report (DBusGProxy *, char const *, GHashTable *,
+    gpointer);
+
 /* ---------------------------------------------------------------------- */
 
 ModemRequest *modem_sms_set_sc_address (ModemSMSService *self,


### PR DESCRIPTION
SMS History (status reports) is in a separate oFono API now. Create a new interface class to listen. Also fixes some compiler warnings. 
