### PR TITLE
[telepathy-ring] Fix possible segfaults with G_DISABLE_CHECKS active

### DIFF
--- a/modem/oface.c
+++ b/modem/oface.c
@@ -186,7 +186,8 @@ modem_oface_finalize (GObject *object)
   DEBUG ("enter");
 
   /* Free any data held directly by the object here */
-  g_object_unref (self->priv->proxy);
+  if (self->priv->proxy)
+    g_object_unref (self->priv->proxy);
   g_clear_error (&self->priv->connecting.error);
 
   G_OBJECT_CLASS (modem_oface_parent_class)->finalize (object);

--- a/modem/sms-message.c
+++ b/modem/sms-message.c
@@ -151,7 +151,8 @@ modem_sms_message_finalize (GObject *object)
   ModemSMSMessage *self = MODEM_SMS_MESSAGE (object);
   g_free (self->destination);
   g_free (self->message_token);
-  g_object_unref (self->message_proxy);
+  if (self->message_proxy)
+    g_object_unref (self->message_proxy);
   G_OBJECT_CLASS (modem_sms_message_parent_class)->finalize (object);
 }
 

--- a/modem/tests/test-modem-request.c
+++ b/modem/tests/test-modem-request.c
@@ -451,16 +451,7 @@ START_TEST(free_assumptions)
   array = g_ptr_array_new();
   fail_if(g_ptr_array_free(array, FALSE) != NULL);
 
-  g_message("Expect some CRITICAL warnings from (process:%u)",
-    (unsigned)getpid());
-
-  fail_if(g_ptr_array_free(NULL, TRUE) != NULL);
-  fail_if(g_ptr_array_free(NULL, FALSE) != NULL);
-
-  g_object_unref(NULL);
   mark_point();
-
-  fail_if(g_object_ref(NULL) != NULL);
 
   array = g_ptr_array_new();
 
@@ -477,10 +468,6 @@ START_TEST(free_assumptions)
   g_strfreev((char **)g_ptr_array_free(array, FALSE));
 
   g_clear_error(&error);
-  g_error_free(NULL);
-
-  g_message("CRITICAL warnings from (process:%u) end here",
-    (unsigned)getpid());
 }
 END_TEST
 


### PR DESCRIPTION
According to the free_assumptions test case, modem code originally
assumed g_ptr_array_free(), g_object_ref(), g_object_unref() and
g_error_free() can be passed NULL safely. This is true unless glib2
is built with G_DISABLE_CHECKS - which is the case of non-devel Mer
build.

This commit ensures no code rely on this assumption anymore and relaxes
the free_assumptions test case.
